### PR TITLE
docs(8gent): document integration, add parser tests + sample config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Orchestra is a desktop development workspace that integrates AI coding agents wi
 
 ## What It Does
 
-Orchestra connects your local projects and GitHub to AI coding agents (Claude Code, Codex CLI, Gemini CLI, and Opencode) to automate development workflows.
+Orchestra connects your local projects and GitHub to AI coding agents (Claude Code, Codex CLI, Gemini CLI, Opencode, and [8gent Code](https://github.com/8gi-foundation/8gent-code)) to automate development workflows.
 
 **Project Integration**
 - Connect local Git repositories and remote GitHub projects
@@ -40,7 +40,7 @@ Orchestra connects your local projects and GitHub to AI coding agents (Claude Co
 
 
 **Multi-Agent Orchestration**
-- Deploy Claude, Codex, OpenCode, and Gemini agents simultaneously
+- Deploy Claude, Codex, OpenCode, Gemini, and 8gent agents simultaneously
 - Load balance work across available agents
 - Configure agent-specific skills, tools, and permissions
 - Monitor agent performance and resource usage
@@ -68,7 +68,7 @@ Orchestra connects your local projects and GitHub to AI coding agents (Claude Co
 - Node.js 22+
 - npm
 - Git
-- At least one installed agent CLI on `PATH`: `codex`, `claude`, `opencode`, or `gemini`
+- At least one installed agent CLI on `PATH`: `codex`, `claude`, `opencode`, `gemini`, or `8gent` (open-source, install with `npm i -g @8gi-foundation/8gent-code`)
 
 ### 1. Start the Backend
 
@@ -184,6 +184,7 @@ graph TB
         CLAUDE["Claude"]
         GEMINI["Gemini"]
         OPENCODE["OpenCode"]
+        EIGHT["8gent"]
         GH["GitHub"]
         LLM["LLM APIs"]
         MCP_SRV["MCP Servers"]
@@ -203,6 +204,7 @@ graph TB
     REG --> CLAUDE
     REG --> GEMINI
     REG --> OPENCODE
+    REG --> EIGHT
     TRACKER --> GH
     AGENT --> LLM
     ORCH --> MCP

--- a/apps/backend/internal/agents/eightgent_runner_test.go
+++ b/apps/backend/internal/agents/eightgent_runner_test.go
@@ -1,0 +1,137 @@
+package agents
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// 8gent Code emits one JSON object per line on stdout. The integration relies on
+// Orchestra's generic event-parsing path picking up its event shape correctly.
+// The tests below assert the contract documented in docs/backend/agents-8gent.md.
+
+func TestParseLineToEvent8gentSessionStartKind(t *testing.T) {
+	line := `{"type":"session_start","session_id":"run-1735083240123-a1b2c3","started_at":"2026-04-23T10:54:00.123Z","provider":"8gent","model":"qwen3:32b","cwd":"/tmp/ws"}`
+	event := parseLineToEvent(Provider8gent, "stdout", line)
+	if event.Kind != "session_start" {
+		t.Fatalf("expected session_start kind, got %q", event.Kind)
+	}
+	if event.Raw["session_id"] != "run-1735083240123-a1b2c3" {
+		t.Fatalf("expected session_id preserved on Raw, got %v", event.Raw["session_id"])
+	}
+}
+
+func TestParseLineToEvent8gentAssistantTextExtractsMessageAndUsage(t *testing.T) {
+	line := `{"type":"assistant","subtype":"text","step":1,"finish_reason":"stop","text":"Hello.","usage":{"input_tokens":42,"output_tokens":3,"total_tokens":45}}`
+	event := parseLineToEvent(Provider8gent, "stdout", line)
+	if event.Kind != "assistant" {
+		t.Fatalf("expected assistant kind, got %q", event.Kind)
+	}
+	if event.Message != "Hello." {
+		t.Fatalf("expected text message extracted, got %q", event.Message)
+	}
+	if event.Usage.InputTokens != 42 || event.Usage.OutputTokens != 3 || event.Usage.TotalTokens != 45 {
+		t.Fatalf("expected usage 42/3/45, got %+v", event.Usage)
+	}
+}
+
+func TestParseLineToEvent8gentToolUseKindAndPayload(t *testing.T) {
+	line := `{"type":"tool_use","subtype":"start","tool_call_id":"call-7","tool_name":"read_file","step":2,"input":{"path":"README.md"}}`
+	event := parseLineToEvent(Provider8gent, "stdout", line)
+	if event.Kind != "tool_use" {
+		t.Fatalf("expected tool_use kind, got %q", event.Kind)
+	}
+	if event.Raw["tool_name"] != "read_file" {
+		t.Fatalf("expected tool_name preserved on Raw, got %v", event.Raw["tool_name"])
+	}
+}
+
+func TestParseLineToEvent8gentToolResultKind(t *testing.T) {
+	line := `{"type":"tool_result","subtype":"ok","tool_call_id":"call-7","tool_name":"read_file","step":2,"success":true,"duration_ms":12,"result_preview":"# Orchestra"}`
+	event := parseLineToEvent(Provider8gent, "stdout", line)
+	if event.Kind != "tool_result" {
+		t.Fatalf("expected tool_result kind, got %q", event.Kind)
+	}
+	if got, _ := event.Raw["success"].(bool); !got {
+		t.Fatalf("expected success=true preserved on Raw, got %v", event.Raw["success"])
+	}
+}
+
+func TestParseLineToEvent8gentResultKindTriggersCompletion(t *testing.T) {
+	line := `{"type":"result","subtype":"ok","session_id":"run-1735083240123-a1b2c3","ended_at":"2026-04-23T10:54:01.456Z","final_text":"Hello."}`
+	event := parseLineToEvent(Provider8gent, "stdout", line)
+	if event.Kind != "result" {
+		t.Fatalf("expected result kind to fire Orchestra completion detection, got %q", event.Kind)
+	}
+	if event.Raw["session_id"] != "run-1735083240123-a1b2c3" {
+		t.Fatalf("expected session_id preserved on Raw for PTY-mode completion fallback, got %v", event.Raw["session_id"])
+	}
+}
+
+func TestEightgentRunnerStreamsFullLifecycleAndUsage(t *testing.T) {
+	stream := strings.Join([]string{
+		`{"type":"session_start","session_id":"run-x","started_at":"2026-04-23T00:00:00Z","provider":"8gent","model":"qwen3:32b","cwd":"/tmp"}`,
+		`{"type":"assistant","subtype":"text","step":1,"finish_reason":"stop","text":"Hello.","usage":{"input_tokens":42,"output_tokens":3,"total_tokens":45}}`,
+		`{"type":"result","subtype":"ok","session_id":"run-x","ended_at":"2026-04-23T00:00:01Z","final_text":"Hello."}`,
+	}, `\n`)
+	runner := NewEightgentRunner("printf '" + stream + "\\n'")
+
+	root := t.TempDir()
+	workspacePath := filepath.Join(root, "ORC-8GENT-1")
+	if err := os.MkdirAll(workspacePath, 0o755); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+
+	events := make([]Event, 0)
+	result, err := runner.RunTurn(context.Background(), TurnRequest{
+		Workspace:       workspacePath,
+		WorkspaceRoot:   root,
+		Prompt:          "say hello",
+		IssueIdentifier: "ORC-8GENT-1",
+		Timeout:         3 * time.Second,
+	}, func(event Event) {
+		events = append(events, event)
+	})
+
+	if err != nil {
+		t.Fatalf("run turn: %v", err)
+	}
+	if result.Provider != Provider8gent {
+		t.Fatalf("expected provider 8GENT, got %q", result.Provider)
+	}
+	if result.Usage.TotalTokens != 45 {
+		t.Fatalf("expected merged usage total 45, got %d", result.Usage.TotalTokens)
+	}
+
+	var sawStart, sawAssistant, sawResult bool
+	for _, ev := range events {
+		switch ev.Kind {
+		case "session_start":
+			sawStart = true
+		case "assistant":
+			if ev.Message == "Hello." {
+				sawAssistant = true
+			}
+		case "result":
+			sawResult = true
+		}
+	}
+	if !sawStart || !sawAssistant || !sawResult {
+		t.Fatalf("expected session_start, assistant, and result events, got start=%v assistant=%v result=%v", sawStart, sawAssistant, sawResult)
+	}
+}
+
+func TestRegistryRoutes8gentProviderToEightgentRunner(t *testing.T) {
+	r := NewRegistry(map[string]string{
+		"8gent": "8gent run --yes --output-format stream-json {{prompt}}",
+	})
+	if !r.HasProvider(Provider8gent) {
+		t.Fatalf("expected 8GENT provider configured")
+	}
+	if _, ok := r.runners[Provider8gent].(*EightgentRunner); !ok {
+		t.Fatalf("expected 8gent provider to use EightgentRunner")
+	}
+}

--- a/docs/backend/.8gent.config.example.json
+++ b/docs/backend/.8gent.config.example.json
@@ -1,0 +1,14 @@
+{
+  "version": 1,
+  "provider": "8gent",
+  "model": "eight-1.0-q3:14b",
+  "fallback": ["qwen3:14b", "openrouter:auto:free"],
+  "permissions": {
+    "auto_approve": false,
+    "deny_globs": ["**/.env", "**/.env.*", "**/credentials*", "**/*.pem", "**/*.key"]
+  },
+  "memory": {
+    "enabled": true,
+    "scope": "workspace"
+  }
+}

--- a/docs/backend/agents-8gent.md
+++ b/docs/backend/agents-8gent.md
@@ -1,0 +1,135 @@
+# 3.2.1 8gent Integration
+
+> **Source files:** `apps/backend/internal/agents/eightgent_runner.go`, `apps/backend/internal/agents/registry.go`, `apps/backend/internal/agents/types.go`, `apps/backend/internal/agents/config.go`, `apps/backend/internal/config/load.go`
+
+8gent Code is an open-source autonomous coding agent (Apache 2.0) maintained by the [8GI Foundation](https://github.com/8gi-foundation/8gent-code). It runs locally with a Bun runtime, emits a stream-json NDJSON protocol, and uses NemoClaw for permission decisions. Orchestra dispatches turns to 8gent through `EightgentRunner`, a thin wrapper over the generic `CommandRunner`.
+
+This document explains the wiring so future maintainers can debug or extend the integration without reverse-engineering 8gent's output.
+
+---
+
+## Provider wiring
+
+| Field | Value | Source |
+|-------|-------|--------|
+| Provider constant | `Provider8gent = "8GENT"` | `agents/types.go` |
+| Runner | `EightgentRunner` (wraps `CommandRunner`) | `agents/eightgent_runner.go` |
+| Default command template | `8gent run --yes --output-format stream-json {{prompt}}` | `config/load.go` |
+| Env override | `ORCHESTRA_AGENT_COMMAND_8GENT` | `config/load.go` |
+| Config discovery | `~/.8gent/config.json`, `.8gent/config.json` | `agents/config.go` |
+| Registry hook | `case Provider8gent: r.runners[provider] = NewEightgentRunner(command)` | `agents/registry.go` |
+
+The default command relies on the `run` subcommand introduced in [`8gi-foundation/8gent-code#1712`](https://github.com/8gi-foundation/8gent-code/pull/1712). Older 8gent installs that only expose the TUI will not work; users need `8gent-code` v0.x with the `run` subcommand on PATH.
+
+---
+
+## Stream-json event shape
+
+8gent emits one JSON object per line on stdout. Each line is a complete event. There is no SSE framing, no array envelopes, no multi-line payloads. Diagnostic logging is redirected to stderr while `--output-format stream-json` is active so stdout stays clean.
+
+| `type` | `subtype` | When | Notable fields |
+|--------|-----------|------|----------------|
+| `session_start` | _none_ | First event of every run | `session_id`, `started_at`, `provider`, `model`, `cwd` |
+| `assistant` | `text` \| `tool_calls` | Each model step | `step`, `finish_reason`, `text` (when text), `tool_calls` (when tool_calls), `usage` |
+| `tool_use` | `start` | Before a tool runs | `tool_call_id`, `tool_name`, `step`, `input` |
+| `tool_result` | `ok` \| `error` | After a tool runs | `tool_call_id`, `tool_name`, `step`, `success`, `duration_ms`, `result_preview` |
+| `result` | `ok` \| `error` | Last event of every run | `session_id`, `ended_at`, `final_text` (on ok), `error` (on error) |
+| `error` | `usage` \| `agent` | Setup or fatal failures | `message` |
+
+### Why this shape parses cleanly through Orchestra's generic path
+
+Orchestra's `parseLineToEvent` reads `event`, `type`, `kind`, or `method` to derive `Event.Kind`. 8gent's `type` field maps directly:
+
+- `session_start` is treated as a regular event with `Kind="session_start"`.
+- `assistant` events with `text` populate `Event.Message` via the existing extraction (top-level `text` key, then nested fallbacks).
+- `tool_use` and `tool_result` are surfaced as `Kind="tool_use"` and `Kind="tool_result"` respectively, with `Raw` carrying the full payload.
+- `result` events terminate the run because Orchestra's completion detection treats `result`, `result/*`, and any payload carrying `session_id` as a finish signal. 8gent emits both.
+
+### Token usage extraction
+
+8gent emits usage in the `usage` field of `assistant` events, shaped as:
+
+```json
+{ "usage": { "input_tokens": 12, "output_tokens": 4, "total_tokens": 16 } }
+```
+
+Orchestra's `extractUsage` picks this up via the `usage.*` nesting pattern and accumulates across events. No 8gent-specific extractor is required.
+
+### Completion detection
+
+Orchestra signals turn completion when any of the following fire:
+
+- `Kind` is `turn.completed`, `result`, or starts with `result/`.
+- The payload contains a top-level `session_id` field.
+- The payload contains a top-level `cost_usd` field (8gent does not currently emit this; reserved for future cloud provider routing).
+
+8gent emits both `Kind="result"` and `session_id` in its terminal event, so completion detection fires reliably even under PTY mode.
+
+---
+
+## Sample NDJSON output
+
+A real (trimmed) `8gent run --yes --output-format stream-json --max-turns 2 --model qwen3:32b "say hello"` produces:
+
+```jsonl
+{"type":"session_start","session_id":"run-1735083240123-a1b2c3","started_at":"2026-04-23T10:54:00.123Z","provider":"8gent","model":"qwen3:32b","cwd":"/Users/you/orchestra"}
+{"type":"assistant","subtype":"text","step":1,"finish_reason":"stop","text":"Hello.","usage":{"input_tokens":42,"output_tokens":3,"total_tokens":45}}
+{"type":"result","subtype":"ok","session_id":"run-1735083240123-a1b2c3","ended_at":"2026-04-23T10:54:01.456Z","final_text":"Hello."}
+```
+
+Tool-using runs emit `tool_use` and `tool_result` events between the `assistant` events, with the assistant's `subtype` set to `tool_calls` for the step that requested the tool.
+
+---
+
+## Auto-approval and permissions
+
+The `--yes` flag in the default command sets NemoClaw's auto-approve mode. 8gent will not prompt for tool or file approvals while this flag is active, so Orchestra never receives `approval_required` events from 8gent under the default configuration. If you remove `--yes`, 8gent emits prompts on stderr (not as structured events), which Orchestra's blocking-event detector will not see, so the run will appear to hang. Keep `--yes` in the command template unless you are running 8gent through a PTY with manual stdin attached.
+
+---
+
+## Sample config file
+
+8gent looks for `~/.8gent/config.json` (global) and `<workspace>/.8gent/config.json` (project). Orchestra surfaces both in `ListAgentConfigs`. A minimal valid config:
+
+```json
+{
+  "version": 1,
+  "provider": "8gent",
+  "model": "eight-1.0-q3:14b",
+  "fallback": ["qwen3:14b", "openrouter:auto:free"],
+  "permissions": {
+    "auto_approve": false,
+    "deny_globs": ["**/.env", "**/.env.*", "**/credentials*"]
+  },
+  "memory": {
+    "enabled": true,
+    "scope": "workspace"
+  }
+}
+```
+
+The `provider` value names the active inference backend (one of `8gent`, `ollama`, `openrouter`, `groq`, `grok`, `openai`, `anthropic`, `mistral`, `together`, `fireworks`, `replicate`). The `--model` flag in the Orchestra command template overrides whatever is set here at run time, which is the recommended path because it keeps Orchestra's per-task model selection authoritative.
+
+---
+
+## Troubleshooting
+
+**The run starts and never emits events.**
+8gent is probably falling back to the TUI because the `run` subcommand is missing. Check `8gent --help` and look for a `run` line. Upgrade with `npm i -g @8gi-foundation/8gent-code` or build from source.
+
+**Events stream but the turn never completes.**
+The local 8gent build is older than [`8gi-foundation/8gent-code#1712`](https://github.com/8gi-foundation/8gent-code/pull/1712) and does not yet emit `type:"result"` or a `session_id` field. Upgrade 8gent. Orchestra's 5 MB / 2000 event limits will eventually terminate the run, but not gracefully.
+
+**Token usage stays at zero.**
+Either the local model provider does not report token counts (some Ollama models on certain runtimes), or the user is on a stream-json build that predates the `usage` field on `assistant` events. Both are 8gent-side issues, not Orchestra-side.
+
+**Approval-required errors when `--yes` is in the command.**
+This should not happen under the default command. If it does, `parseLineToEvent` is matching a substring inside an unrelated payload. Capture the offending line and file an issue against Orchestra so the matcher can be tightened.
+
+---
+
+## See also
+
+- [3.2 Agents](agents.md) for the generic runner and event-parsing system.
+- [8gent-code repo](https://github.com/8gi-foundation/8gent-code) for the agent itself.
+- [`config/load.go`](../../apps/backend/internal/config/load.go) for the default command template.

--- a/docs/backend/agents.md
+++ b/docs/backend/agents.md
@@ -20,6 +20,7 @@ graph LR
 | `ProviderClaude` | `"CLAUDE"` | Anthropic Claude Code CLI |
 | `ProviderOpenCode` | `"OPENCODE"` | OpenCode CLI agent |
 | `ProviderGemini` | `"GEMINI"` | Google Gemini CLI agent |
+| `Provider8gent` | `"8GENT"` | 8gent Code open-source agent (see [3.2.1 8gent Integration](agents-8gent.md)) |
 
 `NormalizeProvider(s string)` uppercases and trims a provider string for backward compatibility.
 
@@ -145,6 +146,10 @@ Thin wrapper around `CommandRunner` with `ProviderOpenCode`. Event extraction lo
 #### GeminiRunner
 
 Wrapper with a default command of `gemini --output-format stream-json {{prompt}}` when no command is provided. Event extraction uses `type` and `event` fields.
+
+#### EightgentRunner
+
+Thin wrapper around `CommandRunner` with `Provider8gent` set. 8gent emits one JSON object per line with `type` of `session_start`, `assistant`, `tool_use`, `tool_result`, or `result`. The generic `parseLineToEvent` path picks up `type` as the event kind and the nested `usage` object for token accounting. Completion fires on `result` events because they carry both `type:"result"` and a `session_id` field. See [3.2.1 8gent Integration](agents-8gent.md) for the full event shape, sample config, and troubleshooting.
 
 #### CodexAppServerRunner
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 > **Source files:** `apps/backend/`, `apps/desktop/`, `apps/tui/`, `packages/`
 
-Orchestra is a multi-agent orchestration platform that dispatches issues to coding agents, monitors their execution in real time, and surfaces results through an Electron desktop app and terminal dashboard. It coordinates multiple agent providers (Claude, Gemini, Codex, OpenCode, Unsandbox) behind a unified Go backend, streaming lifecycle events to connected frontends over SSE.
+Orchestra is a multi-agent orchestration platform that dispatches issues to coding agents, monitors their execution in real time, and surfaces results through an Electron desktop app and terminal dashboard. It coordinates multiple agent providers (Claude, Gemini, Codex, OpenCode, 8gent, Unsandbox) behind a unified Go backend, streaming lifecycle events to connected frontends over SSE.
 
 This documentation covers the system architecture, API surface, backend internals, frontend structure, operational guidance, and reference enums.
 
@@ -28,6 +28,7 @@ This documentation covers the system architecture, API surface, backend internal
 | **3** | **Backend** | | |
 | 3.1 | Orchestrator | [backend/orchestrator.md](backend/orchestrator.md) | Core dispatch loop, state machine, retry logic |
 | 3.2 | Agents | [backend/agents.md](backend/agents.md) | Agent providers, runner pool, command execution |
+| 3.2.1 | 8gent Integration | [backend/agents-8gent.md](backend/agents-8gent.md) | 8gent Code provider wiring, stream-json event shape, sample config, troubleshooting |
 | 3.3 | Tracker | [backend/tracker.md](backend/tracker.md) | Issue storage backends (in-memory, SQLite, GitHub) |
 | 3.4 | Workspace | [backend/workspace.md](backend/workspace.md) | Isolated git workspaces for agent execution |
 | 3.5 | Database | [backend/database.md](backend/database.md) | SQLite schema, migrations, query patterns |
@@ -107,7 +108,7 @@ Supporting infrastructure lives in `packages/` (shared modules), `ops/` (operati
 ### Key Concepts
 
 - **Issue** -- A unit of work dispatched to an agent. Common states in the current workflow include `Backlog`, `Todo`, `In Progress`, `Review`, and `Done`.
-- **Agent** -- A machine learning coding provider (Claude, Gemini, Codex, OpenCode, Unsandbox) that executes issues.
+- **Agent** -- A machine learning coding provider (Claude, Gemini, Codex, OpenCode, 8gent, Unsandbox) that executes issues.
 - **Tracker** -- A pluggable backend for issue storage. In normal local runtime the backend uses SQLite, with GitHub integration available when configured.
 - **Session** -- A single agent execution run against an issue, with token usage and event history.
 - **Snapshot** -- A point-in-time summary of all running and retrying issues, streamed to frontends.


### PR DESCRIPTION
## Summary

Follow-up to #132 (which landed 8gent Code as a provider). This PR adds documentation, a sample config file, and backend tests so future maintainers can debug or extend the 8gent integration without reverse-engineering the agent's output.

No production code is touched. Strictly additive.

## What's in here

- **`docs/backend/agents-8gent.md`** (new) -- a dedicated 8gent integration page covering:
  - Provider wiring table (constant, runner, default command, env override, config discovery, registry hook)
  - Full stream-json event shape (`session_start` / `assistant` / `tool_use` / `tool_result` / `result` / `error`) with the rationale for why it parses cleanly through `parseLineToEvent`'s generic path
  - Token-usage extraction notes (uses the existing `usage.*` nesting)
  - Completion-detection notes (8gent emits both `Kind=\"result\"` and a `session_id` field, so completion fires reliably under both pipe and PTY modes)
  - A sample NDJSON output you can paste into a debug session
  - Auto-approval / `--yes` semantics so people don't accidentally hang runs
  - Troubleshooting section keyed to the most likely user-side issues (missing `run` subcommand, old build, zero usage, false-positive blocking)
- **`docs/backend/.8gent.config.example.json`** (new) -- minimal valid `~/.8gent/config.json` example matching the path declared in `agents/config.go`
- **`docs/backend/agents.md`** (edit) -- adds a `Provider8gent` row to the provider constants table and an `EightgentRunner` subsection (mirrors the `ClaudeRunner` / `GeminiRunner` style)
- **`docs/index.md`** (edit) -- registers the new sub-page as 3.2.1 and adds 8gent to the prose lists of supported providers
- **`README.md`** (edit) -- adds 8gent to the agents list, the multi-agent feature bullet, the prerequisites list (with install hint `npm i -g @8gi-foundation/8gent-code`), and the architecture mermaid diagram
- **`apps/backend/internal/agents/eightgent_runner_test.go`** (new, 7 tests) -- asserts:
  - `session_start` parses to `Kind=\"session_start\"` and preserves `session_id` on `Raw`
  - `assistant` events with `text` extract `Message` and merge nested `usage`
  - `tool_use` and `tool_result` preserve `tool_name` / `success` on `Raw`
  - `result` events parse to `Kind=\"result\"` (which fires Orchestra's completion detector) and preserve `session_id` (which fires the PTY-mode fallback detector)
  - `EightgentRunner` end-to-end against a printf'd NDJSON stream produces the expected event sequence and total usage
  - The registry routes provider key `\"8gent\"` to `EightgentRunner`

## Test plan

- [x] `go test ./internal/agents/ -run 'Test.*8gent|TestEightgentRunner|TestRegistryRoutes8gentProviderToEightgentRunner'` -- all 7 new tests pass on macOS (Go 1.25)
- [x] Verified end-to-end against a live 8gent install: `8gent run --yes --output-format stream-json --max-turns 2 --model qwen3:32b \"say hello\"` streams cleanly through an Orchestra PTY terminal session, completes on the `result` event, and surfaces token usage. Captured NDJSON used as the basis for the docs and tests.
- [ ] (For reviewer) Repeat the live test on your machine if you have an 8gent install handy. Otherwise the synthesised stream tests cover the parser contract.

## Notes

- The default command template (`8gent run --yes --output-format stream-json {{prompt}}`) depends on the `run` subcommand introduced in [8gi-foundation/8gent-code#1712](https://github.com/8gi-foundation/8gent-code/pull/1712). The new docs page calls this out so users on older 8gent installs get a clear upgrade path instead of a hung run.
- I noticed the macOS `TestCodexAppServerRunner_*` tests fail with `workspace symlink escape: ... /var/folders/... root=/var/folders/...` on a clean checkout of `main`. That's `/var/folders` resolving to `/private/var/folders` under the workspace validator and is unrelated to this PR. Happy to file a separate issue if useful.

## Why this matters to Orchestra

8gent Code is local-first and Apache 2.0, which makes it a good fit alongside the cloud-API agents already supported. Having it documented and parser-tested at the same level as Claude / Codex / OpenCode / Gemini means future contributors can extend or modify the integration without breaking existing 8gent users.