### PR TITLE
feat(8gent): explicit extractKind branch + native skill paths

### DIFF
--- a/apps/backend/internal/agents/command_runner.go
+++ b/apps/backend/internal/agents/command_runner.go
@@ -678,6 +678,20 @@ func extractKind(provider Provider, source string, payload map[string]any) strin
 		}
 	}
 
+	if provider == Provider8gent {
+		if eventType := firstString(payload, "type"); eventType != "" {
+			switch eventType {
+			case "session_start", "assistant", "tool_use", "tool_result":
+				return eventType
+			case "result", "error":
+				if subtype := firstString(payload, "subtype"); subtype != "" {
+					return eventType + "/" + subtype
+				}
+				return eventType
+			}
+		}
+	}
+
 	return kind
 }
 

--- a/apps/backend/internal/agents/config.go
+++ b/apps/backend/internal/agents/config.go
@@ -76,8 +76,8 @@ var AgentMeta = map[string]struct {
 		GlobalPaths:      []string{".8gent/config.json"},
 		LocalPaths:       []string{".8gent/config.json"},
 		Format:           "json",
-		GlobalSkillPaths: []string{".claude/skills", ".claude/agents"},
-		LocalSkillPaths:  []string{".claude/skills", ".claude/agents"},
+		GlobalSkillPaths: []string{".8gent/skills", ".8gent/agents", ".8gent/memory"},
+		LocalSkillPaths:  []string{".8gent/skills", ".8gent/agents", ".8gent/memory"},
 	},
 }
 

--- a/apps/backend/internal/agents/eightgent_extractkind_test.go
+++ b/apps/backend/internal/agents/eightgent_extractkind_test.go
@@ -1,0 +1,154 @@
+package agents
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// These tests cover the Provider8gent-specific branch of extractKind and the
+// 8gent entry in AgentMeta. They are intentionally separate from the broader
+// runner-lifecycle tests so they remain readable as the integration grows.
+
+func TestExtractKind8gentMapsTopLevelTypesExplicitly(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload map[string]any
+		want    string
+	}{
+		{
+			name:    "session_start stays plain",
+			payload: map[string]any{"type": "session_start", "session_id": "run-x"},
+			want:    "session_start",
+		},
+		{
+			name:    "assistant stays plain (subtype is informational, not terminal)",
+			payload: map[string]any{"type": "assistant", "subtype": "text"},
+			want:    "assistant",
+		},
+		{
+			name:    "tool_use stays plain",
+			payload: map[string]any{"type": "tool_use", "subtype": "start"},
+			want:    "tool_use",
+		},
+		{
+			name:    "tool_result stays plain so it does not match the result/ completion prefix",
+			payload: map[string]any{"type": "tool_result", "subtype": "ok"},
+			want:    "tool_result",
+		},
+		{
+			name:    "result/ok promotes subtype so completion detection still fires",
+			payload: map[string]any{"type": "result", "subtype": "ok", "session_id": "run-x"},
+			want:    "result/ok",
+		},
+		{
+			name:    "result/error preserves error subtype",
+			payload: map[string]any{"type": "result", "subtype": "error", "error": "boom"},
+			want:    "result/error",
+		},
+		{
+			name:    "result without subtype falls back to plain result",
+			payload: map[string]any{"type": "result"},
+			want:    "result",
+		},
+		{
+			name:    "error/usage promotes subtype",
+			payload: map[string]any{"type": "error", "subtype": "usage", "message": "rate limited"},
+			want:    "error/usage",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractKind(Provider8gent, "stdout", tc.payload)
+			if got != tc.want {
+				t.Fatalf("extractKind(%v) = %q, want %q", tc.payload, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractKind8gentFallsThroughForUnknownTypes(t *testing.T) {
+	payload := map[string]any{"type": "custom_event", "detail": "anything"}
+	if got := extractKind(Provider8gent, "stdout", payload); got != "custom_event" {
+		t.Fatalf("expected fall-through to custom_event, got %q", got)
+	}
+}
+
+func TestAgentMeta8gentUsesNativeSkillPaths(t *testing.T) {
+	meta, ok := AgentMeta["8gent"]
+	if !ok {
+		t.Fatal("expected 8gent entry in AgentMeta")
+	}
+
+	for _, p := range meta.GlobalSkillPaths {
+		if filepath.Dir(p) != ".8gent" && p != ".8gent" && filepath.HasPrefix(p, ".claude") {
+			t.Fatalf("8gent global skill path should not point inside .claude (got %q)", p)
+		}
+	}
+	for _, p := range meta.LocalSkillPaths {
+		if filepath.HasPrefix(p, ".claude") {
+			t.Fatalf("8gent local skill path should not point inside .claude (got %q)", p)
+		}
+	}
+
+	wantLocal := map[string]bool{".8gent/skills": false, ".8gent/agents": false, ".8gent/memory": false}
+	for _, p := range meta.LocalSkillPaths {
+		if _, ok := wantLocal[p]; ok {
+			wantLocal[p] = true
+		}
+	}
+	for path, found := range wantLocal {
+		if !found {
+			t.Fatalf("expected 8gent local skill paths to include %q", path)
+		}
+	}
+}
+
+func TestListAgentConfigsClassifies8gentResources(t *testing.T) {
+	home := t.TempDir()
+	projectRoot := t.TempDir()
+	workspaceRoot := t.TempDir()
+	t.Setenv("HOME", home)
+
+	mustWriteFile(t, filepath.Join(home, ".8gent", "config.json"), `{"version":1,"provider":"8gent","model":"eight-1.0-q3:14b"}`)
+	mustWriteFile(t, filepath.Join(projectRoot, ".8gent", "config.json"), `{"version":1,"provider":"ollama","model":"qwen3:14b"}`)
+	mustWriteFile(t, filepath.Join(projectRoot, ".8gent", "skills", "release", "SKILL.md"), "# Release runbook\n")
+	mustWriteFile(t, filepath.Join(projectRoot, ".8gent", "memory", "MEMORY.md"), "# Memory index\n")
+
+	configs, err := ListAgentConfigs(workspaceRoot, projectRoot)
+	if err != nil {
+		t.Fatalf("ListAgentConfigs: %v", err)
+	}
+
+	want := []string{
+		filepath.Join(home, ".8gent", "config.json"),
+		filepath.Join(projectRoot, ".8gent", "config.json"),
+		filepath.Join(projectRoot, ".8gent", "skills", "release", "SKILL.md"),
+		filepath.Join(projectRoot, ".8gent", "memory", "MEMORY.md"),
+	}
+	for _, path := range want {
+		if !containsConfigPath(configs, path) {
+			t.Fatalf("expected ListAgentConfigs to surface %s, got %d configs", path, len(configs))
+		}
+	}
+}
+
+func containsConfigPath(configs []AgentConfig, path string) bool {
+	for _, cfg := range configs {
+		if cfg.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
+// guard against a future refactor that accidentally removes the 8gent entry
+func TestAgentMeta8gentEntryStillPresent(t *testing.T) {
+	if _, ok := AgentMeta["8gent"]; !ok {
+		t.Fatal("AgentMeta lost its 8gent entry; do not remove without coordinating with the EightgentRunner contract")
+	}
+	if _, err := os.Stat(filepath.Join("eightgent_runner.go")); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("unexpected error stating eightgent_runner.go: %v", err)
+	}
+}

--- a/apps/backend/internal/agents/eightgent_runner_test.go
+++ b/apps/backend/internal/agents/eightgent_runner_test.go
@@ -63,8 +63,11 @@ func TestParseLineToEvent8gentToolResultKind(t *testing.T) {
 func TestParseLineToEvent8gentResultKindTriggersCompletion(t *testing.T) {
 	line := `{"type":"result","subtype":"ok","session_id":"run-1735083240123-a1b2c3","ended_at":"2026-04-23T10:54:01.456Z","final_text":"Hello."}`
 	event := parseLineToEvent(Provider8gent, "stdout", line)
-	if event.Kind != "result" {
-		t.Fatalf("expected result kind to fire Orchestra completion detection, got %q", event.Kind)
+	// Orchestra's completion detection fires on "result" or any "result/*" kind.
+	// The 8gent extractKind branch promotes the subtype (e.g. "result/ok"),
+	// so accept either shape here.
+	if event.Kind != "result" && !strings.HasPrefix(event.Kind, "result/") {
+		t.Fatalf("expected result or result/<subtype> kind, got %q", event.Kind)
 	}
 	if event.Raw["session_id"] != "run-1735083240123-a1b2c3" {
 		t.Fatalf("expected session_id preserved on Raw for PTY-mode completion fallback, got %v", event.Raw["session_id"])
@@ -108,14 +111,12 @@ func TestEightgentRunnerStreamsFullLifecycleAndUsage(t *testing.T) {
 
 	var sawStart, sawAssistant, sawResult bool
 	for _, ev := range events {
-		switch ev.Kind {
-		case "session_start":
+		switch {
+		case ev.Kind == "session_start":
 			sawStart = true
-		case "assistant":
-			if ev.Message == "Hello." {
-				sawAssistant = true
-			}
-		case "result":
+		case ev.Kind == "assistant" && ev.Message == "Hello.":
+			sawAssistant = true
+		case ev.Kind == "result" || strings.HasPrefix(ev.Kind, "result/"):
 			sawResult = true
 		}
 	}


### PR DESCRIPTION
## Summary

Follow-up to #132 (8gent provider runner) and #139 (docs + parser tests).

This PR adds the runtime code that the parser tests in #139 were already asserting against, plus fixes the 8gent entry in `AgentMeta` so its skill/agent/memory directories point at native `.8gent/*` paths instead of `.claude/*`.

After this lands, Orchestra's event stream classifies 8gent's NDJSON output explicitly (no more falling through to generic detection), and `ListAgentConfigs` surfaces the right resources for projects that use 8gent natively.

## What's in this PR

### 1. `extractKind` — explicit Provider8gent branch (`apps/backend/internal/agents/command_runner.go`)

```go
if provider == Provider8gent {
    if eventType := firstString(payload, "type"); eventType != "" {
        switch eventType {
        case "session_start", "assistant", "tool_use", "tool_result":
            return eventType
        case "result", "error":
            if subtype := firstString(payload, "subtype"); subtype != "" {
                return eventType + "/" + subtype
            }
            return eventType
        }
    }
}
```

Notes on the design:

- `session_start`, `assistant`, `tool_use`, `tool_result` are returned as the plain top-level type. `tool_result` is **deliberately** in the plain case rather than the subtype-promotion case — `strings.Contains(\"tool_result/ok\", \"result/\")` would otherwise be `true`, which would falsely fire Orchestra's completion detection (the `Kind == \"result\" || strings.Contains(Kind, \"result/\")` branch in the dispatch path).
- `result` and `error` are promoted to `result/ok`, `result/error`, `error/usage`, etc. when a `subtype` is present. This keeps the semantic information from the stream-json contract while still satisfying the existing `strings.Contains(Kind, \"result/\")` completion detection.
- Unknown 8gent types fall through to the generic kind extraction so we don't accidentally swallow new event shapes.

### 2. `AgentMeta[\"8gent\"]` — native skill paths (`apps/backend/internal/agents/config.go`)

Before:

```go
GlobalSkillPaths: []string{\".claude/skills\", \".claude/agents\"},
LocalSkillPaths:  []string{\".claude/skills\", \".claude/agents\"},
```

After:

```go
GlobalSkillPaths: []string{\".8gent/skills\", \".8gent/agents\", \".8gent/memory\"},
LocalSkillPaths:  []string{\".8gent/skills\", \".8gent/agents\", \".8gent/memory\"},
```

8gent ships its own native config tree at `.8gent/`, so the skill/agent/memory discovery should look there, not at `.claude/*`. The `.claude/*` paths in the original entry were inherited from a copy of the Claude Code wiring.

`GlobalPaths` / `LocalPaths` are intentionally left as just `.8gent/config.json` to avoid colliding with codex's `AGENTS.md` classification (covered by `TestListAgentConfigsClassifiesProviderResources`).

### 3. Tests

**New: `eightgent_extractkind_test.go` (12 cases)**

- `TestExtractKind8gentMapsTopLevelTypesExplicitly` — 8 sub-cases covering every shape above, including the `tool_result` -> `tool_result` (plain) guarantee.
- `TestExtractKind8gentFallsThroughForUnknownTypes` — proves the branch doesn't swallow unknown event types.
- `TestAgentMeta8gentUsesNativeSkillPaths` — guards the skill/memory paths against future regressions.
- `TestListAgentConfigsClassifies8gentResources` — end-to-end check that `~/.8gent/config.json`, `<project>/.8gent/config.json`, `.8gent/skills/<id>/SKILL.md`, and `.8gent/memory/MEMORY.md` are all surfaced.
- `TestAgentMeta8gentEntryStillPresent` — guard against a future refactor accidentally dropping the 8gent entry.

**Updated: `eightgent_runner_test.go`**

Two existing assertions tightened to tolerate the promoted `result/<subtype>` kind that this PR introduces:

- `TestParseLineToEvent8gentResultKindTriggersCompletion` accepts `result` or `result/<subtype>`.
- `TestEightgentRunnerStreamsFullLifecycleAndUsage` matches via `strings.HasPrefix(ev.Kind, \"result/\")` so it remains valid under the new extraction.

## Test plan

- [x] `go test -C apps/backend ./internal/agents/ -run 'Test.*8gent|TestExtractKind8gent|TestEightgentRunner|TestRegistryRoutes8gent|TestAgentMeta8gent|TestListAgentConfigsClassifies8gent' -count=1 -v` — all green
- [x] `go test -C apps/backend ./internal/agents/ -count=1` — only the pre-existing macOS \"workspace symlink escape\" failures in `TestCodexAppServerRunner_*` remain (same set documented in #139, present on clean upstream main, unrelated to this PR)
- [x] Verified `tool_result/ok` does **not** trigger Orchestra's completion path (the trap that motivated the explicit case-split)
- [x] Verified `~/.8gent/skills/<id>/SKILL.md` is surfaced by `ListAgentConfigs`

## Refs

- #132 — feat: 8gent provider runner (already merged)
- #139 — docs + parser tests (already merged)

This PR closes the loop on the 8gent integration: provider runner (#132) + docs/contract tests (#139) + production extractKind branch + native skill paths (this PR).