### PR TITLE
fix(editor): eager file loading in store action

### DIFF
--- a/apps/desktop/src/components/workspace/EditorContent.tsx
+++ b/apps/desktop/src/components/workspace/EditorContent.tsx
@@ -11,62 +11,15 @@ export function EditorContent({ file }: EditorContentProps) {
   const setFileContent = useAppStore((s) => s.setFileContent)
   const setFileDirty = useAppStore((s) => s.setFileDirty)
   const theme = useAppStore((s) => s.theme)
-  const config = useAppStore((s) => s.config)
 
   const originalContentRef = useRef<string>('')
 
-  console.log('[EditorContent] render', file.id, 'content:', file.content === null ? 'NULL' : `${file.content.length} chars`)
-
-  // Load file content when file changes
+  // Track original content for dirty detection
   useEffect(() => {
-    console.log('[EditorContent] effect running for', file.id, 'content:', file.content === null ? 'NULL' : 'LOADED')
-    if (file.content !== null) return
-    let cancelled = false
-    const load = async () => {
-      if (!config) {
-        setFileContent(file.id, '// No backend connection configured')
-        return
-      }
-      try {
-        const url = `${config.baseUrl}/api/v1/workspace/file?path=${encodeURIComponent(file.filePath)}`
-        console.log('[EditorContent] loading file:', file.filePath, 'via', url, 'token:', config.apiToken ? 'set' : 'EMPTY')
-        const res = await fetch(url, {
-          headers: config.apiToken ? { Authorization: `Bearer ${config.apiToken}` } : {},
-        })
-        if (!res.ok) {
-          const errBody = await res.text().catch(() => res.statusText)
-          console.error('[EditorContent] HTTP error:', res.status, errBody)
-          if (!cancelled) setFileContent(file.id, `// Error ${res.status}: ${errBody}\n// File: ${file.filePath}`)
-          return
-        }
-        const content = await res.text()
-        console.log('[EditorContent] loaded', content.length, 'chars for', file.filePath)
-        if (!cancelled) {
-          setFileContent(file.id, content)
-          originalContentRef.current = content
-        }
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err)
-        console.error('[EditorContent] fetch error:', msg)
-        if (!cancelled) {
-          setFileContent(file.id, `// Error loading file: ${msg}\n// File: ${file.filePath}`)
-        }
-      }
-    }
-    load()
-    return () => {
-      cancelled = true
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [file.id])
-
-  // Update originalContentRef when switching to a file that's already loaded
-  useEffect(() => {
-    if (file.content !== null && file.content !== undefined && !file.isDirty) {
+    if (file.content !== null && !file.isDirty) {
       originalContentRef.current = file.content
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [file.id])
+  }, [file.id, file.content, file.isDirty])
 
   // Save handler (Ctrl+S / Cmd+S)
   useEffect(() => {

--- a/apps/desktop/src/store/slices/editor-slice.ts
+++ b/apps/desktop/src/store/slices/editor-slice.ts
@@ -48,7 +48,7 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
 
   // ---- Actions --------------------------------------------------------------
   openFile: (filePath: string, relativePath: string) => {
-    const { openFiles } = get()
+    const { openFiles, config } = get()
     const existing = openFiles.find((f) => f.filePath === filePath)
     if (existing) {
       set({ activeFileId: existing.id, activeWorkspaceTab: { type: 'editor', id: existing.id } })
@@ -63,6 +63,34 @@ export const createEditorSlice: StateCreator<AppState, [], [], EditorSlice> = (s
       content: null,
     }
     set({ openFiles: [...openFiles, newFile], activeFileId: newFile.id, activeWorkspaceTab: { type: 'editor', id: newFile.id } })
+
+    // Eagerly load file content via backend API
+    if (config?.baseUrl) {
+      const url = `${config.baseUrl}/api/v1/workspace/file?path=${encodeURIComponent(filePath)}`
+      const headers: Record<string, string> = {}
+      if (config.apiToken) headers['Authorization'] = `Bearer ${config.apiToken}`
+      fetch(url, { headers })
+        .then((res) => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`)
+          return res.text()
+        })
+        .then((content) => {
+          const state = get()
+          set({
+            openFiles: state.openFiles.map((f) =>
+              f.id === filePath ? { ...f, content } : f,
+            ),
+          })
+        })
+        .catch((err) => {
+          const state = get()
+          set({
+            openFiles: state.openFiles.map((f) =>
+              f.id === filePath ? { ...f, content: `// Error: ${err.message}\n// File: ${filePath}` } : f,
+            ),
+          })
+        })
+    }
   },
 
   closeFile: (fileId: string) => {


### PR DESCRIPTION
## Summary

- Move file content loading from EditorContent useEffect into the store's `openFile` action
- Eliminates mount/unmount race conditions that caused "Loading..." forever
- Also includes the generic workspace file/tree backend API endpoints

## Test plan

- [x] `npx vitest run` — 388 passed
- [x] `npx tsc --noEmit` — clean
- [x] `go build ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)