### PR TITLE
feat: move Development tab to first position in sidebar

### DIFF
--- a/apps/desktop/src/layout/sections.tsx
+++ b/apps/desktop/src/layout/sections.tsx
@@ -29,6 +29,12 @@ function SandboxIcon({ className, size }: { className?: string; size?: number })
 /** Sidebar navigation items displayed in the app shell, in display order. */
 export const sidebarItems: SidebarItem[] = [
   {
+    id: 'CONSOLE',
+    label: 'Development',
+    description: 'Editor, terminals, and browser preview',
+    icon: Terminal,
+  },
+  {
     id: 'ISSUES',
     label: 'Tasks',
     description: 'Task board and inspector',
@@ -45,12 +51,6 @@ export const sidebarItems: SidebarItem[] = [
     label: 'Projects',
     description: 'Local workspace grouping',
     icon: FolderTree,
-  },
-  {
-    id: 'CONSOLE',
-    label: 'Development',
-    description: 'Editor, terminals, and browser preview',
-    icon: Terminal,
   },
   {
     id: 'AGENTS',


### PR DESCRIPTION
## Context
User requested to prioritize the Development tab by moving it to the first position in the sidebar navigation.

## Summary
- Reordered `sidebarItems` array in `sections.tsx` to put CONSOLE (Development) first
- Development tab now appears before Tasks, Studio, and Projects tabs  
- Improves workflow by prioritizing access to the development environment

## Test Plan
- [x] Backend: `go test ./...` from `apps/backend/`
- [x] Desktop: `npx vitest run` from `apps/desktop/` 
- [x] Verified sidebar order in browser: Development → Tasks → Studio → Projects